### PR TITLE
Fix setSKU() type error

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please note that all examples utilise private authentication.
 
 ### Create private authentication credentials
 
-Credentials are stored in a POPO model.
+Credentials are stored in a POPO (Plain Old PHP Object) model.
 
 All other examples assume the presence of the following code.
 

--- a/src/AdminApi/Product/Models/Variant.php
+++ b/src/AdminApi/Product/Models/Variant.php
@@ -147,7 +147,7 @@ class Variant
      * @param string $sku
      * @return Variant
      */
-    public function setSku(string $sku): Variant
+    public function setSku(?string $sku): Variant
     {
         $this->sku = $sku;
         return $this;

--- a/src/AdminApi/ScriptTag/Builders/CountScriptTagsRequest.php
+++ b/src/AdminApi/ScriptTag/Builders/CountScriptTagsRequest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Yaspa\AdminApi\ScriptTag\Builders;
+
+use DateTime;
+use Yaspa\AdminApi\ScriptTag\Constants\ScriptTag;
+use Yaspa\Constants\RequestBuilder;
+use Yaspa\Traits\AuthorizedRequestBuilderTrait;
+
+/**
+ * Class CountScriptTagsRequest
+ *
+ * @package Yaspa\AdminApi\ScriptTag\Builders
+ * @see https://help.shopify.com/api/reference/scripttag#count
+ */
+class CountScriptTagsRequest
+{
+    use AuthorizedRequestBuilderTrait;
+
+    const URI_TEMPLATE = 'https://%s.myshopify.com/admin/scripttags/count.json';
+
+    /** @var string $vendor */
+    protected $src;
+
+    /**
+     * CountScriptTagsRequest constructor.
+     */
+    public function __construct()
+    {
+        // Set properties with defaults
+        $this->uriTemplate = self::URI_TEMPLATE;
+        $this->httpMethod = RequestBuilder::GET_HTTP_METHOD;
+        $this->headers = RequestBuilder::JSON_HEADERS;
+        $this->bodyType = RequestBuilder::QUERY_BODY_TYPE;
+        $this->page = RequestBuilder::STARTING_PAGE;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        $array = [];
+
+        if (!empty($this->ids)) {
+            $array['ids'] = implode(',', $this->ids);
+        }
+
+        if (!is_null($this->src)) {
+            $array['src'] = $this->src;
+        }
+
+        return $array;
+    }
+
+    /**
+     * @param string $src
+     * @return CountScriptTagsRequest
+     */
+    public function withSrc(string $vendor): CountScriptTagsRequest
+    {
+        $new = clone $this;
+        $new->src = $src;
+
+        return $new;
+    }
+}

--- a/src/AdminApi/ScriptTag/Builders/CountScriptTagsRequest.php
+++ b/src/AdminApi/ScriptTag/Builders/CountScriptTagsRequest.php
@@ -19,7 +19,7 @@ class CountScriptTagsRequest
 
     const URI_TEMPLATE = 'https://%s.myshopify.com/admin/scripttags/count.json';
 
-    /** @var string $vendor */
+    /** @var string $src */
     protected $src;
 
     /**
@@ -57,7 +57,7 @@ class CountScriptTagsRequest
      * @param string $src
      * @return CountScriptTagsRequest
      */
-    public function withSrc(string $vendor): CountScriptTagsRequest
+    public function withSrc(string $src): CountScriptTagsRequest
     {
         $new = clone $this;
         $new->src = $src;

--- a/src/AdminApi/ScriptTag/Builders/CreateNewScriptTagRequest.php
+++ b/src/AdminApi/ScriptTag/Builders/CreateNewScriptTagRequest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Yaspa\AdminApi\ScriptTag\Builders;
+
+use Yaspa\AdminApi\ScriptTag\Models\ScriptTag as ScriptTagModel;
+use Yaspa\AdminApi\ScriptTag\Transformers\ScriptTag as ScriptTagTransformer;
+use Yaspa\Constants\RequestBuilder;
+use Yaspa\Interfaces\RequestBuilderInterface;
+use Yaspa\Traits\AuthorizedRequestBuilderTrait;
+
+/**
+ * Class CreateNewScriptTagRequest
+ *
+ * @package Yaspa\AdminApi\ScriptTag\Builders
+ * @see https://help.shopify.com/api/reference/scripttag#create
+ */
+class CreateNewScriptTagRequest implements RequestBuilderInterface
+{
+    use AuthorizedRequestBuilderTrait;
+
+    const URI_TEMPLATE = 'https://%s.myshopify.com/admin/scripttag.json';
+
+    /**
+     * Dependencies
+     */
+    /** @var ScriptTagTransformer $scriptTagTransformer */
+    protected $scriptTagTransformer;
+
+    /**
+     * Builder properties
+     */
+    /** @var ScriptTagModel $scriptTagModel */
+    protected $scriptTagModel;
+
+    /**
+     * CreateNewScriptTagRequest constructor.
+     *
+     * @param ScriptTagTransformer $scriptTagTransformer
+     */
+    public function __construct(ScriptTagTransformer $scriptTagTransformer)
+    {
+        $this->scriptTagTransformer = $scriptTagTransformer;
+        $this->uriTemplate = self::URI_TEMPLATE;
+        $this->httpMethod = RequestBuilder::POST_HTTP_METHOD;
+        $this->headers = RequestBuilder::JSON_HEADERS;
+        $this->bodyType = RequestBuilder::JSON_BODY_TYPE;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return ['script_tag' => $this->scriptTagTransformer->toArray($this->scriptTagModel)];
+    }
+
+    /**
+     * @param ScriptTagModel $scriptTagModel
+     * @return CreateNewScriptTagRequest
+     */
+    public function withScriptTag(ScriptTagModel $scriptTagModel): CreateNewScriptTagRequest
+    {
+        $new = clone $this;
+        $new->scriptTagModel = $scriptTagModel;
+
+        return $new;
+    }
+}

--- a/src/AdminApi/ScriptTag/Builders/DeleteScriptTagRequest.php
+++ b/src/AdminApi/ScriptTag/Builders/DeleteScriptTagRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Yaspa\AdminApi\ScriptTag\Builders;
+
+use Yaspa\AdminApi\ScriptTag\Models\ScriptTag as ScriptTagModel;
+use Yaspa\Constants\RequestBuilder;
+use Yaspa\Interfaces\RequestBuilderInterface;
+use Yaspa\Traits\AuthorizedRequestBuilderTrait;
+use Yaspa\Traits\ResourceRequestBuilderTrait;
+
+/**
+ * Class DeleteScriptTagRequest
+ *
+ * @package Yaspa\AdminApi\ScriptTag\Builders
+ * @see https://help.shopify.com/api/reference/scripttag#destroy
+ */
+class DeleteScriptTagRequest implements RequestBuilderInterface
+{
+    use AuthorizedRequestBuilderTrait,
+        ResourceRequestBuilderTrait;
+
+    const URI_TEMPLATE = 'https://%s.myshopify.com/admin/scripttag/%s.json';
+
+    /**
+     * Builder properties
+     */
+    /** @var ScriptTagModel $scriptTagModel */
+    protected $scriptTagModel;
+
+    /**
+     * DeleteScriptTagRequest constructor.
+     */
+    public function __construct()
+    {
+        $this->uriTemplate = self::URI_TEMPLATE;
+        $this->httpMethod = RequestBuilder::DELETE_HTTP_METHOD;
+        $this->headers = RequestBuilder::JSON_HEADERS;
+        $this->bodyType = RequestBuilder::JSON_BODY_TYPE;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function toResourceId()
+    {
+        return $this->scriptTagModel->getId();
+    }
+
+    /**
+     * @param ScriptTagModel $scriptTag
+     * @return DeleteScriptTagRequest
+     */
+    public function with(ScriptTagModel $scriptTag): DeleteScriptTagRequest
+    {
+        $new = clone $this;
+        $new->scriptTagModel = $scriptTag;
+
+        return $new;
+    }
+}

--- a/src/AdminApi/ScriptTag/Builders/GetScriptTagRequest.php
+++ b/src/AdminApi/ScriptTag/Builders/GetScriptTagRequest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Yaspa\AdminApi\ScriptTag\Builders;
+
+use Yaspa\AdminApi\ScriptTag\Models\ScriptTag as ScriptTagModel;
+use Yaspa\Constants\RequestBuilder;
+use Yaspa\Interfaces\RequestBuilderInterface;
+use Yaspa\Traits\AuthorizedRequestBuilderTrait;
+use Yaspa\Traits\ResourceRequestBuilderTrait;
+
+/**
+ * Class GetScriptTagRequest
+ *
+ * @package Yaspa\AdminApi\ScriptTag\Builders
+ * @see https://help.shopify.com/api/reference/scripttag#show
+ */
+class GetScriptTagRequest implements RequestBuilderInterface
+{
+    use AuthorizedRequestBuilderTrait,
+        ResourceRequestBuilderTrait;
+
+    const URI_TEMPLATE = 'https://%s.myshopify.com/admin/scripttag/%s.json';
+
+    /**
+     * Builder properties
+     */
+    /** @var ScriptTagModel $scriptTagModel */
+    protected $scriptTagModel;
+    /** @var ScriptTagsFields $scriptTagFields */
+    protected $scriptTagFields;
+
+    /**
+     * GetScriptTagRequest constructor.
+     */
+    public function __construct()
+    {
+        $this->uriTemplate = self::URI_TEMPLATE;
+        $this->httpMethod = RequestBuilder::GET_HTTP_METHOD;
+        $this->headers = RequestBuilder::JSON_HEADERS;
+        $this->bodyType = RequestBuilder::JSON_BODY_TYPE;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function toResourceId()
+    {
+        return $this->scriptTagModel->getId();
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        $array = [];
+
+        if (!is_null($this->scriptTagFields)) {
+            $array['fields'] = implode(',', $this->scriptTagFields->getFields());
+        }
+
+        return $array;
+    }
+
+    /**
+     * @param ScriptTagModel $scriptTagModel
+     * @return GetScriptTagRequest
+     */
+    public function withScriptTag(ScriptTagModel $scriptTagModel): GetScriptTagRequest
+    {
+        $new = clone $this;
+        $new->scriptTagModel = $scriptTagModel;
+
+        return $new;
+    }
+
+    /**
+     * @param ScriptTagFields $scriptTagFields
+     * @return GetScriptTagRequest
+     */
+    public function withScriptTagFields(ScriptTagFields $scriptTagFields): GetScriptTagRequest
+    {
+        $new = clone $this;
+        $new->scriptTagFields = $scriptTagFields;
+
+        return $new;
+    }
+}

--- a/src/AdminApi/ScriptTag/Builders/ModifyExisitingScriptTagRequest.php
+++ b/src/AdminApi/ScriptTag/Builders/ModifyExisitingScriptTagRequest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Yaspa\AdminApi\ScriptTag\Builders;
+
+use Yaspa\AdminApi\ScriptTag\Models\ScriptTag as ScriptTagModel;
+use Yaspa\AdminApi\ScriptTag\Models\ScriptTag;
+use Yaspa\AdminApi\ScriptTag\Transformers\ScriptTag as ScriptTagTransformer;
+use Yaspa\Constants\RequestBuilder;
+use Yaspa\Filters\ArrayFilters;
+use Yaspa\Interfaces\RequestBuilderInterface;
+use Yaspa\Traits\AuthorizedRequestBuilderTrait;
+use Yaspa\Traits\ResourceRequestBuilderTrait;
+
+/**
+ * Class ModifyExistingScriptTagRequest
+ *
+ * @package Yaspa\AdminApi\ScriptTag\Builders
+ * @see https://help.shopify.com/api/reference/scripttag#update
+ */
+class ModifyExistingScriptTagRequest implements RequestBuilderInterface
+{
+    use AuthorizedRequestBuilderTrait,
+        ResourceRequestBuilderTrait;
+
+    const URI_TEMPLATE = 'https://%s.myshopify.com/admin/scripttag/%s.json';
+
+    /**
+     * Dependencies
+     */
+    /** @var ScriptTagTransformer $scriptTagTransformer */
+    protected $scriptTagTransformer;
+    /** @var ArrayFilters $arrayFilters */
+    protected $arrayFilters;
+
+    /**
+     * Builder properties
+     */
+    /** @var  ScriptTagModel $scriptTagModel */
+    protected $scriptTagModel;
+
+    /**
+     * ModifyExistingScriptTagRequest constructor.
+     *
+     * @param ScriptTagTransformer $scriptTagTransformer
+     */
+    public function __construct(
+        ScriptTagTransformer $scriptTagTransformer,
+        ArrayFilters $arrayFilters
+    ) {
+        $this->scriptTagTransformer = $scriptTagTransformer;
+        $this->arrayFilters = $arrayFilters;
+        $this->uriTemplate = self::URI_TEMPLATE;
+        $this->httpMethod = RequestBuilder::PUT_HTTP_METHOD;
+        $this->headers = RequestBuilder::JSON_HEADERS;
+        $this->bodyType = RequestBuilder::JSON_BODY_TYPE;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function toResourceId()
+    {
+        return $this->scriptTagModel->getId();
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        $array = [];
+
+        // Transform model
+        if (!is_null($this->scriptTagModel)) {
+            $array = $this->scriptTagTransformer->toArray($this->scriptTagModel);
+        }
+
+        // Retain only not null values
+        $array = $this->arrayFilters->arrayFilterRecursive($array, [$this->arrayFilters, 'notNull']);
+
+        return ['script_tag' => $array];
+    }
+
+    /**
+     * @param ScriptTag $scriptTag
+     * @return ModifyExistingScriptTagRequest
+     */
+    public function withScriptTag(ScriptTagModel $scriptTag): ModifyExistingScriptTagRequest
+    {
+        $new = clone $this;
+        $new->scriptTagModel = $scriptTag;
+
+        return $new;
+    }
+}

--- a/src/AdminApi/ScriptTag/Builders/ScriptTagFields.php
+++ b/src/AdminApi/ScriptTag/Builders/ScriptTagFields.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Yaspa\AdminApi\ScriptTag\Builders;
+
+/**
+ * Class ScriptTagFields
+ *
+ * @package Yaspa\AdminApi\ScriptTag\Builders
+ * @see https://help.shopify.com/api/reference/scripttag#index
+ *
+ * Possible fields to be included with return data resulting from a get scripttags call.
+ */
+class ScriptTagFields
+{
+    const ID = 'id';
+    const SRC = 'src';
+    const EVENT = 'event';
+    const CREATED_AT = 'created_at';
+    const UPDATED_AT = 'updated_at';
+    const DISPAY_SCOPE = 'display_scope';
+
+    /** @var string $fields */
+    protected $fields;
+
+    /**
+     * ScriptTagFields constructor.
+     */
+    public function __construct()
+    {
+        $this->fields = [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFields(): array
+    {
+        return array_unique($this->fields);
+    }
+
+    /**
+     * @return ScriptTagFields
+     */
+    public function withId(): ScriptTagFields
+    {
+        $new = clone $this;
+        $new->fields[] = self::ID;
+
+        return $new;
+    }
+
+    /**
+     * @return ScriptTagFields
+     */
+    public function withSrc(): ScriptTagFields
+    {
+        $new = clone $this;
+        $new->fields[] = self::SRC;
+
+        return $new;
+    }
+
+    /**
+     * @return ScriptTagFields
+     */
+    public function withEvent(): ScriptTagFields
+    {
+        $new = clone $this;
+        $new->fields[] = self::EVENT;
+
+        return $new;
+    }
+
+    /**
+     * @return ScriptTagFields
+     */
+    public function withCreatedAt(): ScriptTagFields
+    {
+        $new = clone $this;
+        $new->fields[] = self::CREATED_AT;
+
+        return $new;
+    }
+
+    /**
+     * @return ScriptTagFields
+     */
+    public function withUpdatedAt(): ScriptTagFields
+    {
+        $new = clone $this;
+        $new->fields[] = self::UPDATED_AT;
+
+        return $new;
+    }
+
+    /**
+     * @return ScriptTagFields
+     */
+    public function withDisplayScope(): ScriptTagFields
+    {
+        $new = clone $this;
+        $new->fields[] = self::DISPLAY_SCOPE;
+
+        return $new;
+    }
+}

--- a/src/AdminApi/ScriptTag/Constants/ScriptTag.php
+++ b/src/AdminApi/ScriptTag/Constants/ScriptTag.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Yaspa\AdminApi\ScriptTag\Constants;
+
+/**
+ * Class ScriptTag
+ *
+ * @package Yaspa\AdminApi\ScriptTag\Constants
+ * @see https://help.shopify.com/api/reference/scripttag
+ */
+class ScriptTag
+{
+    const DISPLAY_SCOPE_ALL = 'all';
+    const DISPLAY_SCOPE_ONLINE_STORE = 'online_store';
+    const DISPLAY_SCOPE_ORDER_STATUS = 'order_status';
+    const DISPLAY_SCOPES = [
+        self::DISPLAY_SCOPE_ALL,
+        self::DISPLAY_SCOPE_ONLINE_STORE,
+        self::DISPLAY_SCOPE_ORDER_STATUS,
+    ];
+    const EVENT_ONLOAD = 'onload';
+}

--- a/src/AdminApi/ScriptTag/Models/ScriptTag.php
+++ b/src/AdminApi/ScriptTag/Models/ScriptTag.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Yaspa\AdminApi\ScriptTag\Models;
+
+use DateTime;
+use stdClass;
+
+/**
+ * Class ScriptTag
+ *
+ * @package Yaspa\AdminApi\ScriptTag\Models
+ * @see https://help.shopify.com/api/reference/scripttag#show
+ */
+class ScriptTag
+{
+    /** @var int $id */
+    protected $id;
+    /** @var string $src */
+    protected $src;
+    /** @var string $event */
+    protected $event;
+    /** @var DateTime $createdAt */
+    protected $createdAt;
+    /** @var DateTime $updatedAt */
+    protected $updatedAt;
+
+    /**
+     * @return int
+     */
+    public function getId():? int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     * @return ScriptTag
+     */
+    public function setId(int $id): ScriptTag
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSrc():? string
+    {
+        return $this->src;
+    }
+
+    /**
+     * @param string $src
+     * @return ScriptTag
+     */
+    public function setSrc(string $src): ScriptTag
+    {
+        $this->src = $src;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEvent():? string
+    {
+        return $this->event;
+    }
+
+    /**
+     * @param string $event
+     * @return ScriptTag
+     */
+    public function setEvent(string $event): ScriptTag
+    {
+        $this->event = $event;
+        return $this;
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getCreatedAt():? DateTime
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @param DateTime $createdAt
+     * @return ScriptTag
+     */
+    public function setCreatedAt(DateTime $createdAt): ScriptTag
+    {
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getUpdatedAt():? DateTime
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * @param DateTime $updatedAt
+     * @return ScriptTag
+     */
+    public function setUpdatedAt(DateTime $updatedAt): ScriptTag
+    {
+        $this->updatedAt = $updatedAt;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayScope():? string
+    {
+        return $this->displayScope;
+    }
+
+    /**
+     * @param string $displayScope
+     * @return ScriptTag
+     */
+    public function setDisplayScope(string $displayScope): ScriptTag
+    {
+        $this->displayScope = $displayScope;
+        return $this;
+    }
+}

--- a/src/AdminApi/ScriptTag/ScriptTagFactoryProvider.php
+++ b/src/AdminApi/ScriptTag/ScriptTagFactoryProvider.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Yaspa\AdminApi\ScriptTag;
+
+use GuzzleHttp;
+use Yaspa\Builders\PagedResultsIterator;
+use Yaspa\Filters\ArrayFilters;
+use Yaspa\Interfaces\FactoryInterface;
+use Yaspa\Interfaces\FactoryProviderInterface;
+
+/**
+ * Class ScriptTagFactoryProvider
+ *
+ * @package Yaspa\AdminApi\ScriptTag
+ */
+class ScriptTagFactoryProvider implements FactoryProviderInterface
+{
+    /**
+     * @param FactoryInterface $factory
+     * @return array
+     */
+    public static function makeConstructors(FactoryInterface $factory): array
+    {
+        return [
+            Builders\CountScriptTagsRequest::class => function () {
+                return new Builders\CountScriptTagsRequest();
+            },
+            Builders\CreateNewProductRequest::class => function () use ($factory) {
+                return new Builders\CreateNewProductRequest(
+                    $factory::make(Transformers\Product::class)
+                );
+            },
+            Builders\DeleteProductRequest::class => function () {
+                return new Builders\DeleteProductRequest();
+            },
+            Builders\GetProductRequest::class => function () {
+                return new Builders\GetProductRequest();
+            },
+            Builders\GetProductsRequest::class => function () {
+                return new Builders\GetProductsRequest();
+            },
+            Builders\ModifyExistingProductRequest::class => function () use ($factory) {
+                return new Builders\ModifyExistingProductRequest(
+                    $factory::make(Transformers\Product::class),
+                    $factory::make(Metafield\Transformers\Metafield::class),
+                    $factory::make(ArrayFilters::class)
+                );
+            },
+            Builders\ProductFields::class => function () {
+                return new Builders\ProductFields();
+            },
+            ProductService::class => function () use ($factory) {
+                return new ProductService(
+                    $factory::make(GuzzleHttp\Client::class),
+                    $factory::make(Transformers\Product::class),
+                    $factory::make(Metafield\Transformers\Metafield::class),
+                    $factory::make(Builders\CreateNewProductRequest::class),
+                    $factory::make(Builders\GetProductRequest::class),
+                    $factory::make(Builders\DeleteProductRequest::class),
+                    $factory::make(Metafield\Builders\GetResourceMetafieldsRequest::class),
+                    $factory::make(PagedResultsIterator::class)
+                );
+            },
+            Transformers\Product::class => function () use ($factory) {
+                return new Transformers\Product(
+                    $factory::make(Transformers\Variant::class),
+                    $factory::make(Transformers\Image::class),
+                    $factory::make(Metafield\Transformers\Metafield::class)
+                );
+            },
+            Transformers\Image::class => function () {
+                return new Transformers\Image();
+            },
+            Transformers\Variant::class => function () {
+                return new Transformers\Variant();
+            },
+        ];
+    }
+}

--- a/src/AdminApi/ScriptTag/ScriptTagService.php
+++ b/src/AdminApi/ScriptTag/ScriptTagService.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Yaspa\AdminApi\ScriptTag;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Promise\PromiseInterface;
+use Yaspa\AdminApi\ScriptTag\Builders\GetScriptTagRequest;
+use Yaspa\AdminApi\ScriptTag\Models\ScriptTag;
+use Yaspa\AdminApi\ScriptTag\Transformers\ScriptTag as ScriptTagTransformer;
+use Yaspa\Interfaces\RequestCredentialsInterface;
+
+/**
+ * Class Service
+ *
+ * @package Yaspa\AdminApi\Shop
+ * @see https://help.shopify.com/api/reference/scripttag
+ *
+ * Shopify scripttag details service.
+ */
+class ScriptTagService
+{
+    /** @var Client $httpClient */
+    protected $httpClient;
+    /** @var GetScriptTagRequest $getScriptTagRequestBuilder */
+    protected $getScriptTagRequestBuilder;
+    /** @var ScriptTagTransformer $scriptTagTransformer */
+    protected $scriptTagTransformer;
+    /** @var PagedResultsIterator $pagedResultsIteratorBuilder */
+    protected $pagedResultsIteratorBuilder;
+
+    /**
+     * Service constructor.
+     *
+     * @param Client $httpClient
+     * @param GetScriptTagRequest $getScriptTagRequestBuilder
+     * @param ScriptTagTransformer $scriptTagTransformer
+     */
+    public function __construct(
+        Client $httpClient,
+        GetScriptTagRequest $getScriptTagRequestBuilder,
+        ScriptTagTransformer $scriptTagTransformer
+    ) {
+        $this->httpClient = $httpClient;
+        $this->getScriptTagRequestBuilder = $getScriptTagRequestBuilder;
+        $this->scriptTagTransformer = $scriptTagTransformer;
+    }
+
+    /**
+     * Get a list of all script tags based on parameters set in the request.
+     *
+     * @see https://help.shopify.com/api/reference/scripttag#index
+     * @param GetScriptTagsRequest $request
+     * @return PagedResultsIterator|Product[]
+     */
+    public function getScriptTags(GetScriptTagsRequest $request): PagedResultsIterator
+    {
+        return $this->pagedResultsIteratorBuilder
+            ->withRequestBuilder($request)
+            ->withTransformer($this->scriptTagTransformer);
+    }
+
+    /**
+     * Async version of self::getScriptTags
+     *
+     * Please note that results will have to be manually transformed.
+     *
+     * @see hhttps://help.shopify.com/api/reference/scripttag#index
+     * @param GetScriptTagsRequest $request
+     * @return PromiseInterface
+     */
+    public function asyncGetScriptTags(GetScriptTagsRequest $request): PromiseInterface
+    {
+        return $this->httpClient->sendAsync(
+            $request->toRequest(),
+            $request->toRequestOptions()
+        );
+    }
+
+    /**
+     * Count scripttags for a search criteria.
+     *
+     * @see https://help.shopify.com/api/reference/scripttag#count
+     * @param CountScriptTagsRequest $request
+     * @return int
+     * @throws MissingExpectedAttributeException
+     */
+    public function countScriptTags(CountScriptTagsRequest $request): int
+    {
+        $response = $this->asyncCountScriptTags($request)->wait();
+
+        $count = json_decode($response->getBody()->getContents());
+
+        if (!property_exists($count, 'count')) {
+            throw new MissingExpectedAttributeException('count');
+        }
+
+        return intval($count->count);
+    }
+
+    /**
+     * Async version of self::countScriptTags
+     *
+     * @see https://help.shopify.com/api/reference/scripttag#count
+     * @param CountScriptTagsRequest $request
+     * @return PromiseInterface
+     */
+    public function asyncCountScriptTags(CountScriptTagsRequest $request): PromiseInterface
+    {
+        return $this->httpClient->sendAsync(
+            $request->toRequest(),
+            $request->toRequestOptions()
+        );
+    }
+
+    /**
+     * Get an individual scripttag.
+     *
+     * @param RequestCredentialsInterface $credentials
+     * @param int $scriptTagId
+     * @param null|ScriptTagFields $scriptTagFields
+     * @return ScriptTag
+     */
+    public function getScriptTag(
+        RequestCredentialsInterface $credentials,
+        int $scriptTagId,
+        ?ScriptTagFields $scriptTagFields = null
+    ): Product {
+        $response = $this->asyncGetScriptTag($credentials, $scriptTagId, $scriptTagFields)->wait();
+
+        return $this->scriptTagTransformer->fromResponse($response);
+    }
+
+    /**
+     * Async version of self::getScriptTag
+     *
+     * @param RequestCredentialsInterface $credentials
+     * @param int $scriptTagId
+     * @param null|ScriptTagFields $scriptTagFields
+     * @return PromiseInterface
+     */
+    public function asyncGetScriptTag(
+        RequestCredentialsInterface $credentials,
+        int $scriptTagId,
+        ?ScriptTagFields $scriptTagFields = null
+    ): PromiseInterface {
+        $scriptTag = (new ScriptTag())->setId($scriptTagId);
+        $request = $this->getScriptTagRequestBuilder
+            ->withCredentials($credentials)
+            ->withScriptTag($scriptTag);
+
+        if ($scriptTagFields) {
+            $request = $request->withScriptTagFields($scriptTagFields);
+        }
+
+        return $this->httpClient->sendAsync(
+            $request->toResourceRequest(),
+            $request->toRequestOptions()
+        );
+    }
+}

--- a/src/AdminApi/ScriptTag/Transformers/ScriptTag.php
+++ b/src/AdminApi/ScriptTag/Transformers/ScriptTag.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Yaspa\AdminApi\ScriptTag\Transformers;
+
+use DateTime;
+use Psr\Http\Message\ResponseInterface;
+use Yaspa\AdminApi\Product\Models\ScriptTag as ScriptTagModel;
+use Yaspa\Exceptions\MissingExpectedAttributeException;
+use Yaspa\Interfaces\ArrayResponseTransformerInterface;
+use stdClass;
+
+/**
+ * Class ScriptTag
+ *
+ * @package Yaspa\AdminApi\ScriptTag\Transformers
+ * @see https://help.shopify.com/api/reference/scripttag#show
+ *
+ * Transform Shopify scripttag(s) deeply.
+ */
+class ScriptTags implements ArrayResponseTransformerInterface
+{
+    /**
+     * ScriptTag constructor.
+     */
+    public function __construct()
+    {
+
+    }
+
+    /**
+     * @param ResponseInterface $response
+     * @return ScriptTagModel
+     * @throws MissingExpectedAttributeException
+     */
+    public function fromResponse(ResponseInterface $response): ScriptTagModel
+    {
+        $stdClass = json_decode($response->getBody()->getContents());
+
+        if (!property_exists($stdClass, 'script_tag')) {
+            throw new MissingExpectedAttributeException('script_tag');
+        }
+
+        return $this->fromShopifyJsonScriptTag($stdClass->scriptTag);
+    }
+
+    /**
+     * @param ResponseInterface $response
+     * @return array|ScriptTagModel[]
+     * @throws MissingExpectedAttributeException
+     */
+    public function fromArrayResponse(ResponseInterface $response): array
+    {
+        $stdClass = json_decode($response->getBody()->getContents());
+
+        if (!property_exists($stdClass, 'script_tags')) {
+            throw new MissingExpectedAttributeException('script_tags');
+        }
+
+        return array_map([$this, 'fromShopifyJsonScriptTag'], $stdClass->script_tags);
+    }
+
+    /**
+     * @param stdClass $shopifyJsonScriptTag
+     * @return ScriptTagModel
+     */
+    public function fromShopifyJsonScriptTag(stdClass $shopifyJsonScriptTag): ScriptTagModel
+    {
+        $scriptTag = new ScriptTagModel();
+
+        if (property_exists($shopifyJsonScriptTag, 'id')) {
+            $scriptTag->setId($shopifyJsonScriptTag->id);
+        }
+
+        if (property_exists($shopifyJsonScriptTag, 'src')) {
+            $scriptTag->setSrc($shopifyJsonScriptTag->src);
+        }
+
+        if (property_exists($shopifyJsonScriptTag, 'event')) {
+            $scriptTag->setEvent($shopifyJsonScriptTag->event);
+        }
+
+        if (property_exists($shopifyJsonScriptTag, 'created_at')
+            && !empty($shopifyJsonScriptTag->created_at)
+        ) {
+            $createdAt = new DateTime($shopifyJsonScriptTag->created_at);
+            $scriptTag->setCreatedAt($createdAt);
+        }
+
+        if (property_exists($shopifyJsonScriptTag, 'updated_at')
+            && !empty($shopifyJsonScriptTag->updated_at)
+        ) {
+            $updatedAt = new DateTime($shopifyJsonScriptTag->updated_at);
+            $scriptTag->setUpdatedAt($updatedAt);
+        }
+
+        if (property_exists($shopifyJsonScriptTag, 'display_scope')) {
+            $scriptTag->setDisplayScope($shopifyJsonScriptTag->display_scope);
+        }
+
+        return $scriptTag;
+    }
+
+    /**
+     * @param ScriptTagModel $scriptTag
+     * @return array
+     */
+    public function toArray(ScriptTagModel $scriptTag): array
+    {
+        $array = [];
+
+        $array['id'] = $scriptTag->getId();
+        $array['src'] = $scriptTag->getSrc();
+        $array['event'] = $scriptTag->getEvent();
+        $array['created_at'] = ($scriptTag->getCreatedAt()) ? $scriptTag->getCreatedAt()->format(DateTime::ISO8601) : null;
+        $array['updated_at'] = ($scriptTag->getUpdatedAt()) ? $scriptTag->getUpdatedAt()->format(DateTime::ISO8601) : null;
+        $array['display_scope'] = $scriptTag->getDisplayScope();
+
+        /**
+         * Attributes that cannot be empty
+         */
+        if ($scriptTag->getSrc() !== null) {
+            $array['src'] = $scriptTag->getSrc();
+        }
+
+        if ($scriptTag->getEvent() !== null) {
+            $array['event'] = $scriptTag->getEvent();
+        }
+
+        if ($scriptTag->getDisplayScope() !== null) {
+            $array['display_scope'] = $scriptTag->getDisplayScope();
+        }
+
+        return $array;
+    }
+}

--- a/tests/Integration/AdminApi/ScriptTag/ScriptTagServiceTest.php
+++ b/tests/Integration/AdminApi/ScriptTag/ScriptTagServiceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Yaspa\Tests\Integration\AdminApi\ScriptTag;
+
+use GuzzleHttp\Exception\ClientException;
+use Yaspa\AdminApi\ScriptTag\Builders\CountScriptTagsRequest;
+use Yaspa\AdminApi\ScriptTag\Builders\GetScriptTagsRequest;
+use Yaspa\AdminApi\ScriptTag\Builders\ModifyExistingScriptTagRequest;
+use Yaspa\AdminApi\ScriptTag\Builders\ScriptTagFields;
+use Yaspa\AdminApi\ScriptTag\Models\ScriptTag;
+use Yaspa\AdminApi\ScriptTag\ProductService;
+use Yaspa\Tests\Utils\Config as TestConfig;
+use Yaspa\Authentication\Factory\ApiCredentials;
+use Yaspa\Factory;
+use PHPUnit\Framework\TestCase;
+
+class ScriptTagServiceTest extends TestCase
+{
+    /**
+     * @group integration
+     */
+    public function testCanCreateNewScriptTag()
+    {
+        // Get config
+        $config = new TestConfig();
+        $shop = $config->get('shopifyShop');
+        $privateApp = $config->get('shopifyShopApp');
+
+        // Create parameters
+        $credentials = Factory::make(ApiCredentials::class)
+            ->makePrivate(
+                $shop->myShopifySubdomainName,
+                $privateApp->apiKey,
+                $privateApp->password
+            );
+
+        // Create request parameters
+        $scriptTag = (new ScriptTag())
+            ->setSrc('https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js')
+            ->setEvent('onload')
+            ->setDisplayScope('online_store');
+
+        // Create new script tag
+        $service = Factory::make(ScriptTagService::class);
+        $newScriptTag = $service->createNewScriptTag($credentials, $scriptTag);
+        $this->assertInstanceOf(ScriptTag::class, $newScriptTag);
+        $this->assertNotEmpty($newScriptTag->getId());
+        $this->assertNotEmpty($newScriptTag->getSrc());
+        $this->assertNotEmpty($newScriptTag->getEvent());
+        $this->assertNotEmpty($newScriptTag->getDisplayScope());
+
+        return $newProduct;
+    }
+
+    /**
+     * @depends testCanCreateNewScriptTag
+     * @group integration
+     * @param ScriptTag $originalScriptTag
+     */
+    public function testCanDeleteScriptTag(ScriptTag $originalScriptTag)
+    {
+        // Get config
+        $config = new TestConfig();
+        $shop = $config->get('shopifyShop');
+        $privateApp = $config->get('shopifyShopApp');
+
+        // Create parameters
+        $credentials = Factory::make(ApiCredentials::class)
+            ->makePrivate(
+                $shop->myShopifySubdomainName,
+                $privateApp->apiKey,
+                $privateApp->password
+            );
+
+        // Test pre-state
+        $this->assertNotEmpty($originalScriptTag->getId());
+
+        // Test service method
+        $service = Factory::make(ScriptTagService::class);
+        $result = $service->deleteProduct($credentials, $originalScriptTag->getId());
+        $this->assertTrue(is_object($result));
+        $this->assertEmpty(get_object_vars($result));
+    }
+}

--- a/tests/Integration/AdminApi/ScriptTag/ScriptTagServiceTest.php
+++ b/tests/Integration/AdminApi/ScriptTag/ScriptTagServiceTest.php
@@ -8,7 +8,7 @@ use Yaspa\AdminApi\ScriptTag\Builders\GetScriptTagsRequest;
 use Yaspa\AdminApi\ScriptTag\Builders\ModifyExistingScriptTagRequest;
 use Yaspa\AdminApi\ScriptTag\Builders\ScriptTagFields;
 use Yaspa\AdminApi\ScriptTag\Models\ScriptTag;
-use Yaspa\AdminApi\ScriptTag\ProductService;
+use Yaspa\AdminApi\ScriptTag\ScriptTagService;
 use Yaspa\Tests\Utils\Config as TestConfig;
 use Yaspa\Authentication\Factory\ApiCredentials;
 use Yaspa\Factory;
@@ -49,7 +49,7 @@ class ScriptTagServiceTest extends TestCase
         $this->assertNotEmpty($newScriptTag->getEvent());
         $this->assertNotEmpty($newScriptTag->getDisplayScope());
 
-        return $newProduct;
+        return $newScriptTag;
     }
 
     /**
@@ -77,7 +77,7 @@ class ScriptTagServiceTest extends TestCase
 
         // Test service method
         $service = Factory::make(ScriptTagService::class);
-        $result = $service->deleteProduct($credentials, $originalScriptTag->getId());
+        $result = $service->deleteScriptTag($credentials, $originalScriptTag->getId());
         $this->assertTrue(is_object($result));
         $this->assertEmpty(get_object_vars($result));
     }


### PR DESCRIPTION
This change fixes the following type error.

`Argument 1 passed to Yaspa\AdminApi\Product\Models\Variant::setSku() must be of the type string, null given`

The sku field in Shopify is not required and can return a null value.