### PR TITLE
Fix setSKU() type error

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please note that all examples utilise private authentication.
 
 ### Create private authentication credentials
 
-Credentials are stored in a POPO model.
+Credentials are stored in a POPO (Plain Old PHP Object) model.
 
 All other examples assume the presence of the following code.
 

--- a/src/AdminApi/Product/Models/Variant.php
+++ b/src/AdminApi/Product/Models/Variant.php
@@ -147,7 +147,7 @@ class Variant
      * @param string $sku
      * @return Variant
      */
-    public function setSku(string $sku): Variant
+    public function setSku(?string $sku): Variant
     {
         $this->sku = $sku;
         return $this;


### PR DESCRIPTION
This change fixes the following type error.

`Argument 1 passed to Yaspa\AdminApi\Product\Models\Variant::setSku() must be of the type string, null given`

The Variant object SKU field Shopify is not required and will return a null value if not set.